### PR TITLE
Implement CSRF protection

### DIFF
--- a/lib/ueberauth/strategy/linkedin.ex
+++ b/lib/ueberauth/strategy/linkedin.ex
@@ -30,7 +30,8 @@ defmodule Ueberauth.Strategy.LinkedIn do
   @doc """
   Handles the callback from LinkedIn.
   """
-  def handle_callback!(%Plug.Conn{ params: %{ "code" => code, "state" => state } } = conn) do
+  def handle_callback!(%Plug.Conn{params: %{"code" => code,
+                                            "state" => state}} = conn) do
     opts = [redirect_uri: callback_url(conn)]
     token = Ueberauth.Strategy.LinkedIn.OAuth.get_token!([code: code], opts)
 

--- a/lib/ueberauth/strategy/linkedin.ex
+++ b/lib/ueberauth/strategy/linkedin.ex
@@ -17,7 +17,7 @@ defmodule Ueberauth.Strategy.LinkedIn do
   def handle_request!(conn) do
     scopes = conn.params["scope"] || option(conn, :default_scope)
     state =
-      conn.params["state"] || :crypto.strong_rand_bytes(16) |> Base.encode64
+      conn.params["state"] || Base.encode64(:crypto.strong_rand_bytes(16))
 
     opts = [scope: scopes,
             state: state,

--- a/lib/ueberauth/strategy/linkedin.ex
+++ b/lib/ueberauth/strategy/linkedin.ex
@@ -19,6 +19,8 @@ defmodule Ueberauth.Strategy.LinkedIn do
     opts = [ scope: scopes ]
     if conn.params["state"] do
       opts = Keyword.put(opts, :state, conn.params["state"])
+      pid = spawn fn -> csrf_protection(conn.params["state"]) end
+      Process.register(pid, :state_holder)
     end
     opts = Keyword.put(opts, :redirect_uri, callback_url(conn))
 
@@ -28,16 +30,21 @@ defmodule Ueberauth.Strategy.LinkedIn do
   @doc """
   Handles the callback from LinkedIn.
   """
-  def handle_callback!(%Plug.Conn{ params: %{ "code" => code } } = conn) do
+  def handle_callback!(%Plug.Conn{ params: %{ "code" => code, "state" => state } } = conn) do
     opts = [redirect_uri: callback_url(conn)]
     token = Ueberauth.Strategy.LinkedIn.OAuth.get_token!([code: code], opts)
+
+    send :state_holder, {self, state}
 
     if token.access_token == nil do
       token_error = token.other_params["error"]
       token_error_description = token.other_params["error_description"]
       set_errors!(conn, [error(token_error, token_error_description)])
     else
-      fetch_user(conn, token)
+      receive do
+        {:ok, _state} -> fetch_user(conn, token)
+        {:error, reason} -> set_errors!(conn, [error("csrf", reason)])
+      end
     end
   end
 
@@ -129,5 +136,12 @@ defmodule Ueberauth.Strategy.LinkedIn do
 
   defp option(conn, key) do
     Dict.get(options(conn), key, Dict.get(default_options, key))
+  end
+
+  defp csrf_protection(initial_state) do
+    receive do
+      {sender, ^initial_state} -> send sender, {:ok, initial_state}
+      {sender, _} -> send sender, {:error, "CSRF token mismatch"}
+    end
   end
 end


### PR DESCRIPTION
Check if the state parameter returned is consistent with the value sent, as described in the Linkedin OAuth2 documentation: https://developer.linkedin.com/docs/oauth2
