### PR TITLE
Fetch conn cookies before handling the callback

### DIFF
--- a/lib/ueberauth/strategy/linkedin.ex
+++ b/lib/ueberauth/strategy/linkedin.ex
@@ -35,6 +35,8 @@ defmodule Ueberauth.Strategy.LinkedIn do
   """
   def handle_callback!(%Plug.Conn{params: %{"code" => code,
                                             "state" => state}} = conn) do
+    conn = conn |> fetch_cookies
+
     opts = [redirect_uri: callback_url(conn)]
     %OAuth2.Client{token: token} = Ueberauth.Strategy.LinkedIn.OAuth.get_token!([code: code], opts)
 

--- a/mix.lock
+++ b/mix.lock
@@ -12,5 +12,5 @@
   "oauth2": {:hex, :oauth2, "0.8.0", "9650476a695a22c75fa9a0a8fed8094a135ba1972a7f421450e9b10cba3547dd", [:mix], [{:hackney, "~> 1.6", [hex: :hackney, optional: false]}]},
   "plug": {:hex, :plug, "1.2.2", "cfbda521b54c92ab8ddffb173fbaabed8d8fc94bec07cd9bb58a84c1c501b0bd", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},
   "poison": {:hex, :poison, "2.1.0", "f583218ced822675e484648fa26c933d621373f01c6c76bd00005d7bd4b82e27", [:mix], []},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:make, :rebar], []},
   "ueberauth": {:hex, :ueberauth, "0.4.0", "bc72d5e5a7bdcbfcf28a756e34630816edabc926303bdce7e171f7ac7ffa4f91", [:mix], [{:plug, "~> 1.2", [hex: :plug, optional: false]}]}}


### PR DESCRIPTION
Before this commit, L48 at `lib/ueberauth/strategy/linkedin.ex` was trying to access a key from a %Plug.Conn.Unfetched{} struct and failed to handle the callback.

I remember that this dep was working normally before upgrading to Erlang 20 / Elixir 1.4.5, but can't think right now of any change that could be causing this.