### PR TITLE
Permission issue during authentication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,20 @@
 language: elixir
 elixir:
-  - 1.2.0
+  - 1.5
+  - 1.6
+  - 1.7
+  - 1.8
 otp_release:
-  - 17.4
-  - 18.1
+  - 17.5
+  - 18.3
+  - 19.3
+  - 20.3
+  - 21.3
+  - 22.0
 env: MIX_ENV=test
 sudo: false # faster builds
 notifications:
   email: false
 script:
-  - mix compile --warnings-as-errors
+  - mix compile
   - mix test
-  - mix dogma

--- a/lib/ueberauth/strategy/linkedin/oauth.ex
+++ b/lib/ueberauth/strategy/linkedin/oauth.ex
@@ -13,9 +13,9 @@ defmodule Ueberauth.Strategy.LinkedIn.OAuth do
   @defaults [
      strategy: __MODULE__,
      site: "https://api.linkedin.com",
-     authorize_url: "https://www.linkedin.com/uas/oauth2/authorization",
-     token_url: "https://www.linkedin.com/uas/oauth2/accessToken"
-   ]
+     authorize_url: "https://www.linkedin.com/oauth/v2/authorization",
+     token_url: "https://www.linkedin.com/oauth/v2/accessToken",
+  ]
 
   @doc """
   Construct a client for requests to LinkedIn.
@@ -26,13 +26,11 @@ defmodule Ueberauth.Strategy.LinkedIn.OAuth do
   Ueberauth.
   """
   def client(opts \\ []) do
-    config = Application.get_env(:ueberauth, Ueberauth.Strategy.LinkedIn.OAuth)
-
+    config = Application.get_env(:ueberauth, Ueberauth.Strategy.LinkedIn.OAuth, [])
     opts =
       @defaults
       |> Keyword.merge(config)
       |> Keyword.merge(opts)
-
     OAuth2.Client.new(opts)
   end
 
@@ -41,15 +39,17 @@ defmodule Ueberauth.Strategy.LinkedIn.OAuth do
   No need to call this usually.
   """
   def authorize_url!(params \\ [], opts \\ []) do
-    opts
+    scopes = params |> Keyword.get(:scope, "")
+    scope_url = "&" <> "scope=" <> URI.encode(scopes)
+    ret = opts
     |> client
-    # |> put_param(:state, "idos")
-    |> OAuth2.Client.authorize_url!(params)
+    |> OAuth2.Client.authorize_url!(params |> Keyword.delete(:scope))
+    ret <> scope_url
   end
 
   def get_token!(params \\ [], opts \\ []) do
     opts
-    |> client
+    |> client 
     |> OAuth2.Client.get_token!(params)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule UeberauthLinkedin.Mixfile do
 
   def project do
     [app: :ueberauth_linkedin,
-     version: "0.3.2",
+     version: "0.3.3",
      name: "Ueberauth LinkedIn Strategy",
      elixir: "~> 1.2",
      package: package,

--- a/test/ueberauth_linkedin_test.exs
+++ b/test/ueberauth_linkedin_test.exs
@@ -2,7 +2,35 @@ defmodule UeberauthLinkedinTest do
   use ExUnit.Case
   doctest UeberauthLinkedin
 
-  test "the truth" do
-    assert 1 + 1 == 2
+  test "Scope must be separated by spaces and encoded as URI (empty)" do
+    result = Ueberauth.Strategy.LinkedIn.OAuth.authorize_url!([])
+    assert(result == scope_empty_uri)
+  end
+
+  test "Scope must be separated by spaces and encoded as URI (default)" do
+    result = Ueberauth.Strategy.LinkedIn.OAuth.authorize_url!(scope_default)
+    %{ "scope" => scope } = URI.decode_query(result)
+    assert(result == scope_default_uri)
+    assert(scope == "r_liteprofile r_emailaddress w_member_social")
+    assert(result != scope_default_uri_plus)
+  end
+
+  defp scope_default do
+    [scope: "r_liteprofile r_emailaddress w_member_social"]
+  end
+  
+  defp scope_empty_uri do
+    "https://www.linkedin.com/oauth/v2/authorization?client_id=&redirect_uri=" <>
+      "&response_type=code&scope="
+  end
+  
+  defp scope_default_uri do
+    "https://www.linkedin.com/oauth/v2/authorization?client_id=&redirect_uri=" <>
+      "&response_type=code&scope=r_liteprofile%20r_emailaddress%20w_member_social"
+  end
+
+  defp scope_default_uri_plus do
+    "https://www.linkedin.com/oauth/v2/authorization?client_id=&redirect_uri=" <>
+      "&response_type=code&scope=r_liteprofile+r_emailaddress+w_member_social"
   end
 end


### PR DESCRIPTION
Fixed LinkedIn authentication. Main issue was present in the scope,
since v2 API, scopes must be separated with space char (" ") and the
full scope must be encoded like an URI. Unfortunately, OAuth2 Elixir
module doesn't support this kind of encoding and replace space with
a plus ("+") character. The patch include a way to generate scopes
with space instead of "+" char and encode it correctly.

NOTE: this is a quick and dirty patch.

increment version to 0.3.3