### PR TITLE
Handle user not having a profile picture

### DIFF
--- a/lib/ueberauth/strategy/linkedin.ex
+++ b/lib/ueberauth/strategy/linkedin.ex
@@ -160,14 +160,16 @@ defmodule Ueberauth.Strategy.LinkedIn do
     end
   end
 
-  defp info_image(user) do
-    user
-    |> get_in(["profilePicture", "displayImage~", "elements"])
+  defp info_image(%{"profilePicture" => profilePicture} = _user) do
+    profilePicture
+    |> get_in(["displayImage~", "elements"])
     |> List.last()
     |> get_in(["identifiers"])
     |> List.last()
     |> get_in(["identifier"])
   end
+
+  defp info_image(_user), do: nil
 
   defp email_from_primary_contact(primary_contact) do
     email_element = primary_contact["elements"]


### PR DESCRIPTION
Otherwise authenticating as a LinkedIn user without a picture would raise:

** (FunctionClauseError) no function clause matching in List.last/1
    (elixir 1.10.4) lib/list.ex:294: List.last(nil)
    (ueberauth_linkedin 0.3.2) lib/ueberauth/strategy/linkedin.ex:175: Ueberauth.Strategy.LinkedIn.info_image/1